### PR TITLE
fix: set isError flag for blocked AI Guard responses

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -183,6 +183,7 @@ const main = defineCommand({
                 text: `Input has been blocked by Pangea AI Guard.\n\n${JSON.stringify(rest, null, 2)}`,
               },
             ],
+            isError: true,
           };
         }
 
@@ -233,6 +234,7 @@ const main = defineCommand({
                   text: `Output has been blocked by Pangea AI Guard.\n\n${JSON.stringify(rest, null, 2)}`,
                 },
               ],
+              isError: true,
             };
           }
 


### PR DESCRIPTION
Prevents schema validation errors in current Python mcp (1.13.0) Is recommended by the current spec (https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult)

Currently, when a tool returns blocked response in a client written with the [Python SDK](https://github.com/modelcontextprotocol/python-sdk), I get validation error:
> ...
> raise RuntimeError(f"Tool {name} has an output schema but did not return structured content")

While it doesn't seem to exactly correspond to the proposed change, adding `isError: true` eliminates it _and_ including this key is recommended anyway:
> Any errors that originate from the tool SHOULD be reported inside the result object, with isError set to true, not as an MCP protocol-level error response. Otherwise, the LLM would not be able to see that an error occurred and self-correct.